### PR TITLE
Open workspaces in new tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/components/auth0-login-zone/auth0-login-zone.js
+++ b/src/components/auth0-login-zone/auth0-login-zone.js
@@ -51,7 +51,7 @@ export const Auth0LoginZone = ({ auth: { isAuthenticated, isLoading, loginWithRe
             <ul>
               <li className="menu-item">
                 <FolderIcon />
-                <span className="menu-text"><Link to="/user">Workspaces</Link></span>
+                <span className="menu-text"><Link to="/user" target="_blank" rel="noopener noreferrer">Workspaces</Link></span>
               </li>
               {
                 (window.CONTRIBUTE_HOST) &&

--- a/src/components/visualization-list-menu-item/visualization-list-menu-item.js
+++ b/src/components/visualization-list-menu-item/visualization-list-menu-item.js
@@ -17,7 +17,7 @@ const VisualizationListMenuItem = ({isAuthenticated}) => {
     <visualization-list-menu-item>
       <TabButton data-testid="visualization-list-menu-item" className={`button-${isAuthenticated ? 'enabled' : 'disabled'} ${userNeedsLoginInfo && 'dialog-open'}`} onClick={showLoginPrompt}>
         <div title='Saved Workspaces'>
-          <Link to="/user" className={`header-item link-${isAuthenticated ? 'enabled' : 'disabled'}`}>
+          <Link to="/user" target="_blank" rel="noopener noreferrer" className={`header-item link-${isAuthenticated ? 'enabled' : 'disabled'}`}>
             <FolderIcon />
           </Link>
         </div>

--- a/src/pages/user-profile-view/user-profile-view.js
+++ b/src/pages/user-profile-view/user-profile-view.js
@@ -68,7 +68,7 @@ const UserProfileView = (props) => {
   }
 
   if (!isAuthenticated) {
-    return <ErrorComponent errorText={"You must be signed in to see your saved visualizations"} />
+    return <ErrorComponent errorText={"You must be signed in to see your saved visualizations. If you are logged in, but have MFA enabled, ensure that 'Remember Device' is checked."} />
   }
 
   Modal.setAppElement('*')

--- a/src/pages/user-profile-view/user-profile-view.js
+++ b/src/pages/user-profile-view/user-profile-view.js
@@ -68,7 +68,7 @@ const UserProfileView = (props) => {
   }
 
   if (!isAuthenticated) {
-    return <ErrorComponent errorText={"You must be signed in to see your saved visualizations."} />
+    return <ErrorComponent errorText={"You must be signed in to see your saved visualizations"} />
   }
 
   Modal.setAppElement('*')

--- a/src/pages/user-profile-view/user-profile-view.js
+++ b/src/pages/user-profile-view/user-profile-view.js
@@ -68,7 +68,7 @@ const UserProfileView = (props) => {
   }
 
   if (!isAuthenticated) {
-    return <ErrorComponent errorText={"You must be signed in to see your saved visualizations. If you are logged in, but have MFA enabled, ensure that 'Remember Device' is checked."} />
+    return <ErrorComponent errorText={"You must be signed in to see your saved visualizations."} />
   }
 
   Modal.setAppElement('*')


### PR DESCRIPTION
Currently, opening the workspaces view from the sql query page can lose visualization work. This change prevents that, and adds some extra text to the error page to remind MFA users to enable auth0's "Remember Device" feature. (This will be seen more as opening a new tab can log a user out if a new MFA code is required each time)

https://github.com/Datastillery/smartcitiesdata/issues/1225